### PR TITLE
chore: put default locales for errors context

### DIFF
--- a/lib/wariva/gettext.ex
+++ b/lib/wariva/gettext.ex
@@ -24,4 +24,39 @@ defmodule Wariva.Gettext do
   use Gettext,
     otp_app: :wariva,
     default_locale: "en"
+
+  @supported_locales [
+    %{code: "en", name: "English"},
+    %{code: "es", name: "Español"},
+    %{code: "fr", name: "Français"},
+    %{code: "it", name: "Italiano"},
+    %{code: "pt", name: "Português"}
+  ]
+
+  @type locale :: %{code: String.t(), name: String.t()}
+
+  @spec get_locale(String.t()) :: locale() | nil
+  def get_locale(code) do
+    Enum.find(@supported_locales, &(&1.code == code))
+  end
+
+  @doc "Returns the suported locales."
+  @spec get_supported_locales() :: [locale()]
+  def get_supported_locales do
+    @supported_locales
+  end
+
+  @doc "Sets a given locale if it's supported"
+  @spec put_supported_locale(String.t()) :: nil
+  def put_supported_locale(locale) do
+    if known?(locale) do
+      Gettext.put_locale(locale)
+    end
+  end
+
+  @doc "Verifies if the location is a known location by us."
+  @spec known?(String.t()) :: boolean()
+  def known?(locale) do
+    locale in Gettext.known_locales(__MODULE__)
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -48,6 +48,7 @@ defmodule Wariva.MixProject do
   defp aliases do
     [
       setup: ["deps.get", "ecto.setup"],
+      "gettext.update": ["gettext.extract", "gettext.merge priv/gettext/"],
       "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
       test: ["ecto.create --quiet", "ecto.migrate --quiet", "test"],

--- a/priv/gettext/en/LC_MESSAGES/errors.po
+++ b/priv/gettext/en/LC_MESSAGES/errors.po
@@ -49,24 +49,14 @@ msgstr ""
 msgid "are still associated with this entry"
 msgstr ""
 
-## From Ecto.Changeset.validate_length/3
-msgid "should have %{count} item(s)"
-msgid_plural "should have %{count} item(s)"
-msgstr[0] ""
-msgstr[1] ""
-
 msgid "should be %{count} character(s)"
 msgid_plural "should be %{count} character(s)"
 msgstr[0] ""
 msgstr[1] ""
 
-msgid "should be %{count} byte(s)"
-msgid_plural "should be %{count} byte(s)"
-msgstr[0] ""
-msgstr[1] ""
-
-msgid "should have at least %{count} item(s)"
-msgid_plural "should have at least %{count} item(s)"
+## From Ecto.Changeset.validate_length/3
+msgid "should have %{count} item(s)"
+msgid_plural "should have %{count} item(s)"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -75,13 +65,8 @@ msgid_plural "should be at least %{count} character(s)"
 msgstr[0] ""
 msgstr[1] ""
 
-msgid "should be at least %{count} byte(s)"
-msgid_plural "should be at least %{count} byte(s)"
-msgstr[0] ""
-msgstr[1] ""
-
-msgid "should have at most %{count} item(s)"
-msgid_plural "should have at most %{count} item(s)"
+msgid "should have at least %{count} item(s)"
+msgid_plural "should have at least %{count} item(s)"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -90,8 +75,8 @@ msgid_plural "should be at most %{count} character(s)"
 msgstr[0] ""
 msgstr[1] ""
 
-msgid "should be at most %{count} byte(s)"
-msgid_plural "should be at most %{count} byte(s)"
+msgid "should have at most %{count} item(s)"
+msgid_plural "should have at most %{count} item(s)"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/priv/gettext/errors.pot
+++ b/priv/gettext/errors.pot
@@ -7,7 +7,6 @@
 ## Run `mix gettext.extract` to bring this file up to
 ## date. Leave `msgstr`s empty as changing them here has no
 ## effect: edit them in PO (`.po`) files instead.
-
 ## From Ecto.Changeset.cast/4
 msgid "can't be blank"
 msgstr ""

--- a/priv/gettext/es/LC_MESSAGES/errors.po
+++ b/priv/gettext/es/LC_MESSAGES/errors.po
@@ -1,0 +1,87 @@
+## "msgid"s in this file come from POT (.pot) files.
+###
+### Do not add, change, or remove "msgid"s manually here as
+### they're tied to the ones in the corresponding POT file
+### (with the same domain).
+###
+### Use "mix gettext.extract --merge" or "mix gettext.merge"
+### to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: es\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);"
+
+msgid "can't be blank"
+msgstr "no puede estar en blanco"
+
+msgid "has already been taken"
+msgstr "ya se ha tomado"
+
+msgid "is invalid"
+msgstr "es invalido"
+
+msgid "must be accepted"
+msgstr "debe ser aceptado"
+
+msgid "has invalid format"
+msgstr "tiene un formato inválido"
+
+msgid "has an invalid entry"
+msgstr "tiene una entrada inválida"
+
+msgid "is reserved"
+msgstr "está reservado"
+
+msgid "does not match confirmation"
+msgstr "la confirmación no coincide"
+
+msgid "is still associated with this entry"
+msgstr "todavía está asociado con esta entrada"
+
+msgid "are still associated with this entry"
+msgstr "todavía están asociados con esta entrada"
+
+msgid "should be %{count} character(s)"
+msgid_plural "should be %{count} character(s)"
+msgstr[0] "debe ser %{count} caracter"
+msgstr[1] "debe ser de %{count} caracteres"
+
+msgid "should have %{count} item(s)"
+msgid_plural "should have %{count} item(s)"
+msgstr[0] "debería tener %{count} artículo"
+msgstr[1] "debe tener %{count} elementos"
+
+msgid "should be at least %{count} character(s)"
+msgid_plural "should be at least %{count} character(s)"
+msgstr[0] "debe tener al menos %{count} caracter"
+msgstr[1] "debe tener al menos %{count} caracteres"
+
+msgid "should have at least %{count} item(s)"
+msgid_plural "should have at least %{count} item(s)"
+msgstr[0] "debe tener al menos %{count} elemento"
+msgstr[1] "debe tener al menos %{count} elementos"
+
+msgid "should be at most %{count} character(s)"
+msgid_plural "should be at most %{count} character(s)"
+msgstr[0] "debe tener como máximo %{count} carácter"
+msgstr[1] "debe tener como máximo %{count} caracteres"
+
+msgid "should have at most %{count} item(s)"
+msgid_plural "should have at most %{count} item(s)"
+msgstr[0] "debe tener como máximo %{count} elemento"
+msgstr[1] "debe tener como máximo %{count} elementos"
+
+msgid "must be less than %{number}"
+msgstr "debe ser menor que %{number}"
+
+msgid "must be greater than %{number}"
+msgstr "debe ser mayor que %{number}"
+
+msgid "must be less than or equal to %{number}"
+msgstr "debe ser menor o igual que %{number}"
+
+msgid "must be greater than or equal to %{number}"
+msgstr "debe ser mayor o igual que %{number}"
+
+msgid "must be equal to %{number}"
+msgstr "debe ser igual a %{number}"

--- a/priv/gettext/fr/LC_MESSAGES/errors.po
+++ b/priv/gettext/fr/LC_MESSAGES/errors.po
@@ -1,0 +1,87 @@
+## "msgid"s in this file come from POT (.pot) files.
+###
+### Do not add, change, or remove "msgid"s manually here as
+### they're tied to the ones in the corresponding POT file
+### (with the same domain).
+###
+### Use "mix gettext.extract --merge" or "mix gettext.merge"
+### to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: fr\n"
+"Plural-Forms: nplurals=2; plural=(n>1);"
+
+msgid "can't be blank"
+msgstr "ne peut pas être vide"
+
+msgid "has already been taken"
+msgstr "a déjà été pris"
+
+msgid "is invalid"
+msgstr "est invalide"
+
+msgid "must be accepted"
+msgstr "doit être accepté"
+
+msgid "has invalid format"
+msgstr "a un format invalide"
+
+msgid "has an invalid entry"
+msgstr "a une entrée invalide"
+
+msgid "is reserved"
+msgstr "est réservé"
+
+msgid "does not match confirmation"
+msgstr "ne correspond pas à la confirmation"
+
+msgid "is still associated with this entry"
+msgstr "est toujours associé à cette entrée"
+
+msgid "are still associated with this entry"
+msgstr "sont toujours associés à cette entrée"
+
+msgid "should be %{count} character(s)"
+msgid_plural "should be %{count} character(s)"
+msgstr[0] "devrait être %{count} caractère"
+msgstr[1] "devrait être %{count} caractères"
+
+msgid "should have %{count} item(s)"
+msgid_plural "should have %{count} item(s)"
+msgstr[0] "devrait avoir %{count} article"
+msgstr[1] "devrait avoir %{count} articles"
+
+msgid "should be at least %{count} character(s)"
+msgid_plural "should be at least %{count} character(s)"
+msgstr[0] "doit contenir au moins %{count} caractère"
+msgstr[1] "doit comporter au moins %{count} caractères"
+
+msgid "should have at least %{count} item(s)"
+msgid_plural "should have at least %{count} item(s)"
+msgstr[0] "devrait avoir au moins %{count} élément"
+msgstr[1] "doit avoir au moins %{count} éléments"
+
+msgid "should be at most %{count} character(s)"
+msgid_plural "should be at most %{count} character(s)"
+msgstr[0] "doit contenir au plus %{count} caractère"
+msgstr[1] "doit contenir au plus %{count} caractères"
+
+msgid "should have at most %{count} item(s)"
+msgid_plural "should have at most %{count} item(s)"
+msgstr[0] "devrait avoir au plus %{count} élément"
+msgstr[1] "devrait avoir au plus %{count} éléments"
+
+msgid "must be less than %{number}"
+msgstr "doit être inférieur à %{number}"
+
+msgid "must be greater than %{number}"
+msgstr "doit être supérieur à %{number}"
+
+msgid "must be less than or equal to %{number}"
+msgstr "doit être inférieur ou égal à %{number}"
+
+msgid "must be greater than or equal to %{number}"
+msgstr "doit être supérieur ou égal à %{number}"
+
+msgid "must be equal to %{number}"
+msgstr "doit être égal à %{number}"

--- a/priv/gettext/it/LC_MESSAGES/errors.po
+++ b/priv/gettext/it/LC_MESSAGES/errors.po
@@ -1,0 +1,87 @@
+## "msgid"s in this file come from POT (.pot) files.
+###
+### Do not add, change, or remove "msgid"s manually here as
+### they're tied to the ones in the corresponding POT file
+### (with the same domain).
+###
+### Use "mix gettext.extract --merge" or "mix gettext.merge"
+### to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: it\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);"
+
+msgid "can't be blank"
+msgstr "non può essere vuoto"
+
+msgid "has already been taken"
+msgstr "è già stata presa"
+
+msgid "is invalid"
+msgstr "è invalido"
+
+msgid "must be accepted"
+msgstr "deve essere accettato"
+
+msgid "has invalid format"
+msgstr "ha un formato non valido"
+
+msgid "has an invalid entry"
+msgstr "ha una voce non valida"
+
+msgid "is reserved"
+msgstr "è riservato"
+
+msgid "does not match confirmation"
+msgstr "non corrisponde alla conferma"
+
+msgid "is still associated with this entry"
+msgstr "è ancora associato a questa voce"
+
+msgid "are still associated with this entry"
+msgstr "sono ancora associati a questa voce"
+
+msgid "should be %{count} character(s)"
+msgid_plural "should be %{count} character(s)"
+msgstr[0] "dovrebbe essere %{count} carattere"
+msgstr[1] "dovrebbe essere di %{count} caratteri"
+
+msgid "should have %{count} item(s)"
+msgid_plural "should have %{count} item(s)"
+msgstr[0] "dovrebbe avere %{count} elemento"
+msgstr[1] "dovrebbe avere %{count} elementi"
+
+msgid "should be at least %{count} character(s)"
+msgid_plural "should be at least %{count} character(s)"
+msgstr[0] "deve essere di almeno %{count} carattere"
+msgstr[1] "deve essere di almeno %{count} caratteri"
+
+msgid "should have at least %{count} item(s)"
+msgid_plural "should have at least %{count} item(s)"
+msgstr[0] "dovrebbe avere almeno %{count} elemento"
+msgstr[1] "dovrebbe avere almeno %{count} elementi"
+
+msgid "should be at most %{count} character(s)"
+msgid_plural "should be at most %{count} character(s)"
+msgstr[0] "dovrebbe essere al massimo %{count} carattere"
+msgstr[1] "dovrebbe contenere al massimo %{count} caratteri"
+
+msgid "should have at most %{count} item(s)"
+msgid_plural "should have at most %{count} item(s)"
+msgstr[0] "dovrebbe contenere al massimo %{count} elemento"
+msgstr[1] "dovrebbe contenere al massimo %{count} elementi"
+
+msgid "must be less than %{number}"
+msgstr "deve essere inferiore a %{number}"
+
+msgid "must be greater than %{number}"
+msgstr "deve essere maggiore di %{number}"
+
+msgid "must be less than or equal to %{number}"
+msgstr "deve essere minore o uguale a %{number}"
+
+msgid "must be greater than or equal to %{number}"
+msgstr "deve essere maggiore o uguale a %{number}"
+
+msgid "must be equal to %{number}"
+msgstr "deve essere uguale a %{number}"

--- a/priv/gettext/pt/LC_MESSAGES/errors.po
+++ b/priv/gettext/pt/LC_MESSAGES/errors.po
@@ -1,0 +1,87 @@
+## "msgid"s in this file come from POT (.pot) files.
+###
+### Do not add, change, or remove "msgid"s manually here as
+### they're tied to the ones in the corresponding POT file
+### (with the same domain).
+###
+### Use "mix gettext.extract --merge" or "mix gettext.merge"
+### to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: pt\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);"
+
+msgid "can't be blank"
+msgstr "não pode ficar em branco"
+
+msgid "has already been taken"
+msgstr "já foi tomada"
+
+msgid "is invalid"
+msgstr "é inválido"
+
+msgid "must be accepted"
+msgstr "deve ser aceito"
+
+msgid "has invalid format"
+msgstr "tem formato inválido"
+
+msgid "has an invalid entry"
+msgstr "tem uma entrada inválida"
+
+msgid "is reserved"
+msgstr "está reservado"
+
+msgid "does not match confirmation"
+msgstr "não coincide com a confirmação"
+
+msgid "is still associated with this entry"
+msgstr "ainda está associado a esta entrada"
+
+msgid "are still associated with this entry"
+msgstr "ainda estão associados a esta entrada"
+
+msgid "should be %{count} character(s)"
+msgid_plural "should be %{count} character(s)"
+msgstr[0] "deve ser %{count} caractere"
+msgstr[1] "deve ser %{count} caracteres"
+
+msgid "should have %{count} item(s)"
+msgid_plural "should have %{count} item(s)"
+msgstr[0] "deve ter %{count} item"
+msgstr[1] "deve ter %{count} itens"
+
+msgid "should be at least %{count} character(s)"
+msgid_plural "should be at least %{count} character(s)"
+msgstr[0] "deve ter pelo menos %{count} caractere"
+msgstr[1] "deve ter pelo menos %{count} caracteres"
+
+msgid "should have at least %{count} item(s)"
+msgid_plural "should have at least %{count} item(s)"
+msgstr[0] "deveria ter pelo menos %{count} item"
+msgstr[1] "deveria ter pelo menos %{count} itens"
+
+msgid "should be at most %{count} character(s)"
+msgid_plural "should be at most %{count} character(s)"
+msgstr[0] "deve ter no máximo %{count} caractere"
+msgstr[1] "deve ter no máximo %{count} caracteres"
+
+msgid "should have at most %{count} item(s)"
+msgid_plural "should have at most %{count} item(s)"
+msgstr[0] "deve ter no máximo %{count} item"
+msgstr[1] "deve ter no máximo %{count} itens"
+
+msgid "must be less than %{number}"
+msgstr "deve ser menor que %{number}"
+
+msgid "must be greater than %{number}"
+msgstr "deve ser maior que %{number}"
+
+msgid "must be less than or equal to %{number}"
+msgstr "deve ser menor ou igual a %{number}"
+
+msgid "must be greater than or equal to %{number}"
+msgstr "deve ser maior ou igual a %{number}"
+
+msgid "must be equal to %{number}"
+msgstr "deve ser igual a %{number}"

--- a/test/wariva/gettext_test.exs
+++ b/test/wariva/gettext_test.exs
@@ -1,0 +1,69 @@
+defmodule Wariva.GettextTest do
+  @moduledoc false
+
+  use ExUnit.Case
+
+  describe "known?/1" do
+    test "returns true for known locales" do
+      for locale <- Gettext.known_locales(Wariva.Gettext) do
+        assert Wariva.Gettext.known?(locale)
+      end
+    end
+
+    test " returns false for unkown locale" do
+      refute Wariva.Gettext.known?("fa_KE")
+    end
+  end
+
+  describe "get_supported_locales/0" do
+    test "asserts all entries have a code and a name" do
+      locales = Wariva.Gettext.get_supported_locales()
+
+      for locale <- locales do
+        assert is_binary(locale.code)
+        assert is_binary(locale.name)
+      end
+    end
+
+    test "assert that at least english is part of the supported locales" do
+      locales = Wariva.Gettext.get_supported_locales()
+
+      assert Enum.member?(locales, %{
+               code: "en",
+               name: "English"
+             })
+    end
+
+    test "assert that all locales are unique" do
+      locales = Wariva.Gettext.get_supported_locales()
+
+      assert length(locales) == length(Enum.uniq_by(locales, & &1.code))
+    end
+  end
+
+  describe "get_locale/1" do
+    test "returns locale when code is valid" do
+      locales = Wariva.Gettext.get_supported_locales()
+
+      for locale <- locales do
+        assert locale == Wariva.Gettext.get_locale(locale.code)
+      end
+    end
+
+    test "returns nil when code is invalid" do
+      assert nil == Wariva.Gettext.get_locale("invalid")
+    end
+  end
+
+  describe "put_supported_locale/1" do
+    test "puts the locale when code is valid" do
+      Wariva.Gettext.put_supported_locale("pt")
+      assert "pt" == Gettext.get_locale(Wariva.Gettext)
+    end
+
+    test "puts default locale when code is invalid" do
+      Wariva.Gettext.put_supported_locale("invalid")
+      assert "en" == Gettext.get_locale(Wariva.Gettext)
+    end
+  end
+end


### PR DESCRIPTION
This PR updates the locale context for errors.

It includes translations for common romance languages like Portuguese, Spanish, French, and Italian.