### PR TITLE
chore: include coverage badge on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Wariva 🐒
+# Wariva 🐒 [![Coverage Status](https://coveralls.io/repos/github/wariva/wariva/badge.svg?branch=main)](https://coveralls.io/github/wariva/wariva?branch=main)
 
 Wariva is a delightfully simple async communication platform. It's fast, free, and easy to use, with all the features you need to have a successful community. It's also extremely extensible, allowing for ultimate customizability.
 


### PR DESCRIPTION
This PR only updates the `README.md` header to include the coverage badge [from coveralls](https://coveralls.io/github/wariva/wariva).